### PR TITLE
Fix a issue that disabled the header scroll behaviour.

### DIFF
--- a/style.css
+++ b/style.css
@@ -220,7 +220,7 @@ a:has(svg) {
     transform: translateY(0%);
 }
 
-.hide header {
+header {
     --transform-height-1: 0px;
     --transform-height-2: 0px;
     position: fixed;


### PR DESCRIPTION
I don't know how, but i added a `.hide` class (which doesn't exist in my HTML) before the `header` style in CSS which caused the caused behaviour to bug out. (and caused a lot of head-scratching and frustration).